### PR TITLE
Potential security issue in libdap2/daputil.c: Unchecked return from initialization function

### DIFF
--- a/libdap2/daputil.c
+++ b/libdap2/daputil.c
@@ -315,6 +315,7 @@ makeocpathstring(OClink conn, OCddsnode node, const char* sep)
     int i,len,first;
     char* result;
     char* name;
+    name = (void*)0;
     OCtype octype;
     NClist* ocpath = NULL;
     NCbytes* pathname = NULL;
@@ -337,6 +338,7 @@ makeocpathstring(OClink conn, OCddsnode node, const char* sep)
     for(first=1,i=1;i<len;i++) { /* start at 1 to skip dataset name */
 	OCddsnode node = (OCddsnode)nclistget(ocpath,i);
 	char* name;
+	name = (void*)0;
         oc_dds_type(conn,node,&octype);
         oc_dds_name(conn,node,&name);
 	if(!first) ncbytescat(pathname,sep);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

3 instances of this defect were found in the following locations:
---
**Instance 1**
File : `libdap2/daputil.c` 
Function: `oc_dds_name` 
https://github.com/siva-msft/netcdf-c/blob/894ed2625d911c80bd9037dc01bc6f19cd68ec34/libdap2/daputil.c#L327
Code extract:

```cpp
    */
    oc_dds_type(conn,node,&octype);
    if(octype == OC_Dataset) {
        oc_dds_name(conn,node,&name); <------ HERE
	return nulldup(name);
    }
```

---
**Instance 2**
File : `libdap2/daputil.c` 
Function: `oc_dds_name` 
https://github.com/siva-msft/netcdf-c/blob/894ed2625d911c80bd9037dc01bc6f19cd68ec34/libdap2/daputil.c#L341
Code extract:

```cpp
	OCddsnode node = (OCddsnode)nclistget(ocpath,i);
	char* name;
        oc_dds_type(conn,node,&octype);
        oc_dds_name(conn,node,&name); <------ HERE
	if(!first) ncbytescat(pathname,sep);
	ncbytescat(pathname,name);
```

---
**Instance 3**
File : `libdap2/daputil.c` 
Function: `strtol` 
https://github.com/siva-msft/netcdf-c/blob/894ed2625d911c80bd9037dc01bc6f19cd68ec34/libdap2/daputil.c#L597
Code extract:

```cpp
		break;
	      case 'x':
		t++; /* now t points to one or more hex digits */
		*s++ = (char) strtol(t, &endp, 16); <------ HERE
		t = endp;
		break;
```

